### PR TITLE
fix: include note paths in list-notes content[].text response

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -111,7 +111,7 @@ export function createServer(vaultPath) {
 
         let description = result.count === 0
           ? `No notes found${directory ? ` in ${directory}` : ''}`
-          : `Showing ${result.pagination.returned} of ${result.pagination.total} notes${directory ? ` in ${directory}` : ''}`;
+          : `Showing ${result.pagination.returned} of ${result.pagination.total} notes${directory ? ` in ${directory}` : ''}\n\n${result.notes.join('\n')}`;
 
         if (result.pagination.hasMore) {
           const nextOffset = offset + limit;


### PR DESCRIPTION
## Summary

MCP clients that don't support `structuredContent` (e.g. Claude.ai connectors) only read `content[].text`. The `list-notes` handler was putting only a count summary in `content[].text` and the actual file list exclusively in `structuredContent`, making the response appear empty to those clients.

This appends the notes list to the description string so it appears in `content[].text` as a fallback, matching how `discover-mocs` already includes paths in its text output.

## Change

One-line change in `src/server.js` — the `list-notes` description template string now includes `\n\n${result.notes.join('\n')}` after the count summary.

**Before:**
```
Showing 10 of 10 notes in AI/Memory
```

**After:**
```
Showing 10 of 10 notes in AI/Memory

AI/Memory/Affirmation Log.md
AI/Memory/Close-Out Routine.md
AI/Memory/Morning Routine.md
...
```

`structuredContent` is still included for clients that support it.

Fixes #18